### PR TITLE
Improve yamllint ci step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,7 @@ jobs:
 
       - name: Lint YAML sources with yamllint
         run: |
-          sudo -H python3 -m pip install --upgrade pip setuptools wheel
-          sudo -H python3 -m pip install --upgrade yamllint
           yamllint --version
           echo "Linting YAML sources with yamllint ..."
-          yamllint --strict .
+          yamllint --strict --format github .
           echo "OK"


### PR DESCRIPTION
- This package is installed by default in GitHub Actions runners actions/virtual-environments#1142
- Use github warnings output formatter